### PR TITLE
A couple of minor tweaks to the tests and header

### DIFF
--- a/MAKVONotificationCenter.h
+++ b/MAKVONotificationCenter.h
@@ -24,14 +24,6 @@ enum
     //	removing the observation WILL throw KVO errors to the console and cause
     //	crashes!
     MAKeyValueObservingOptionUnregisterManually		= 0x80000000,
-    
-    // Pass this flag to avoid the passing of MAKVONotification objects to
-    //	block-based observer callbacks. This saves an object allocation, at the
-    //	expense of making all the information in the object inaccessible. nil
-    //	will be passed as the parameter to the block. This is really only useful
-    //	if you expect to be getting a LOT of observations and you're worried
-    //	about memory usage and/or microbenchmark speed.
-    MAKeyValueObservingOptionNoInformation			= 0x40000000,
 };
 
 /******************************************************************************/

--- a/MAKVONotificationCenter.m
+++ b/MAKVONotificationCenter.m
@@ -93,7 +93,7 @@ static char MAKVONotificationHelperMagicContext = 0;
         _options = options;
         
         // Pass only Apple's options to Apple's code.
-        options &= ~(MAKeyValueObservingOptionUnregisterManually | MAKeyValueObservingOptionNoInformation);
+        options &= ~(MAKeyValueObservingOptionUnregisterManually);
         
         for (NSString *keyPath in _keyPaths)
         {
@@ -142,8 +142,7 @@ static char MAKVONotificationHelperMagicContext = 0;
 
             // Pass object instead of _target as the notification object so that
             //	array observations will work as expected.
-            if (!(_options & MAKeyValueObservingOptionNoInformation))
-                notification = [[MAKVONotification alloc] initWithObserver:_observer object:object keyPath:keyPath change:change];
+            notification = [[MAKVONotification alloc] initWithObserver:_observer object:object keyPath:keyPath change:change];
             ((void (^)(MAKVONotification *))_userInfo)(notification);
         }
 #endif

--- a/Tests.m
+++ b/Tests.m
@@ -523,4 +523,32 @@
         STAssertFalse(observation.isValid, @"Array target wasn't auto-deregistered on deallocation");
     }
 }
+
+- (void)testSelfObservation
+{
+    @autoreleasepool
+    {
+        TestObject					*object1 = [[[TestObject alloc] init] autorelease];
+        id<MAKVOObservation>		observation = nil;
+        BOOL						__block trigger = NO;
+        
+        observation = [object1 observeTarget:object1 keyPath:@"toggle" options:0 block:^ (MAKVONotification *notification) { trigger = !trigger; }];
+        object1.toggle = YES;
+        STAssertTrue(trigger, @"Trigger didn't fire or fired too many times.");
+        [observation remove];
+        trigger = NO;
+        object1.toggle = NO;
+        STAssertFalse(observation.isValid, @"Observation didn't go invalid.");
+        STAssertFalse(trigger, @"Trigger fired but shouldn't have.");
+        
+        @autoreleasepool
+        {
+            TestObject				*object2 = [[[TestObject alloc] init] autorelease];
+            
+            observation = [object2 addObserver:object2 keyPath:@"toggle" options:0 block:^ (MAKVONotification *notification) { }];
+        }
+        STAssertFalse(observation.isValid, @"Observation didn't automatically deregister.");
+    }
+}
+
 @end

--- a/Tests.m
+++ b/Tests.m
@@ -251,14 +251,6 @@
             STAssertEqualObjects(notification.newValue, [NSNumber numberWithBool:YES], @"Expected new value to be YES, got %@", notification.newValue);
             STAssertFalse(notification.isPrior, @"Expected prior flag to be NO, it wasn't.");
         }];
-        [observation remove];
-
-        /*observation = */[observer observeTarget:target keyPath:@"toggle"
-                                options:MAKeyValueObservingOptionNoInformation | NSKeyValueObservingOptionInitial
-                                block:
-        ^ (MAKVONotification *notification) {
-            STAssertNil(notification, @"Got a notification where none was expected");
-        }];
 //		[observation remove];	// unnecessary!
     }
 }
@@ -545,8 +537,9 @@
         {
             TestObject				*object2 = [[[TestObject alloc] init] autorelease];
             
-            observation = [object2 addObserver:object2 keyPath:@"toggle" options:0 block:^ (MAKVONotification *notification) { }];
+            observation = [[object2 addObserver:object2 keyPath:@"toggle" options:0 block:^ (MAKVONotification *notification) { }] retain];
         }
+        [observation autorelease];
         STAssertFalse(observation.isValid, @"Observation didn't automatically deregister.");
     }
 }


### PR DESCRIPTION
Just a bit of cleanup; I decided the "no information passed to block callback" option was pretty useless. If you're using so many KVO's that you're worried about a single object allocation per call, you can hack it easily to use a thread-specific data value as a cached notification object. Not to mention that since polymorphic block types would complicate the heck out of the API, passing `nil` to callback blocks also seems kinda stupid. I also added another test.
