### PR TITLE
Made it work for iOS < 5.0 and Mac OS X < 10.7

### DIFF
--- a/MAKVONotificationCenter.h
+++ b/MAKVONotificationCenter.h
@@ -168,5 +168,7 @@ enum
 @end
 @interface NSSet (MAKeyPath) <MAKVOKeyPathSet>
 @end
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_5_0 || __MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_7
 @interface NSOrderedSet (MAKeyPath) <MAKVOKeyPathSet>
 @end
+#endif

--- a/MAKVONotificationCenter.m
+++ b/MAKVONotificationCenter.m
@@ -439,6 +439,7 @@ static char MAKVONotificationHelperMagicContext = 0;
 
 @end
 
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_5_0 || __MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_7
 @implementation NSOrderedSet (MAKeyPath)
 
 - (id<NSFastEnumeration>)ma_keyPathsAsSetOfStrings
@@ -447,3 +448,4 @@ static char MAKVONotificationHelperMagicContext = 0;
 }
 
 @end
+#endif

--- a/MAKVONotificationCenter.m
+++ b/MAKVONotificationCenter.m
@@ -161,12 +161,20 @@ static char MAKVONotificationHelperMagicContext = 0;
         NSIndexSet		*idxSet = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, [_target count])];
         
         for (NSString *keyPath in _keyPaths)
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_5_0 || __MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_7
             [_target removeObserver:self fromObjectsAtIndexes:idxSet forKeyPath:keyPath context:&MAKVONotificationHelperMagicContext];
+#else
+            [_target removeObserver:self fromObjectsAtIndexes:idxSet forKeyPath:keyPath];
+#endif
     }
     else
     {
         for (NSString *keyPath in _keyPaths)
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_5_0 || __MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_7
             [_target removeObserver:self forKeyPath:keyPath context:&MAKVONotificationHelperMagicContext];
+#else
+            [_target removeObserver:self forKeyPath:keyPath];
+#endif
     }
 
     if (_observer)

--- a/MAKVONotificationCenter.xcodeproj/project.pbxproj
+++ b/MAKVONotificationCenter.xcodeproj/project.pbxproj
@@ -462,7 +462,6 @@
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
-				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 			};
@@ -480,7 +479,6 @@
 				DYLIB_CURRENT_VERSION = 1;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
-				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 			};
@@ -519,7 +517,6 @@
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				COPY_PHASE_STRIP = NO;
 				DSTROOT = /tmp/MAKVONotificationCenter_iOS.dst;
-				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -533,7 +530,6 @@
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				COPY_PHASE_STRIP = YES;
 				DSTROOT = /tmp/MAKVONotificationCenter_iOS.dst;
-				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;


### PR DESCRIPTION
I made this work for iOS < 5.0 and Mac OS X < 10.7 by checking for the Deployment target. If it's set to something before iOS 5.0 or Mac OS X 10.7, then `NSOrderedSet` won't be used and `-deregister` will use the `-removeObserver:` methods without the context parameter.
With these changes I was able to run this on a project targeted for iOS 4.3 and so far it seems to be working without problems.
