### PR TITLE
Fixed memory leak under ARC.

### DIFF
--- a/MAKVONotificationCenter.h
+++ b/MAKVONotificationCenter.h
@@ -54,7 +54,8 @@ enum
 @property(copy,readonly)	NSString			*keyPath;
 @property(assign,readonly)	id					observer, target;
 @property(assign,readonly)	NSKeyValueChange	kind;
-@property(strong,readonly)	id					oldValue, newValue;
+@property(strong,readonly)	id					oldValue;
+@property(strong,readonly)	id __attribute__((ns_returns_not_retained)) newValue;
 @property(strong,readonly)	NSIndexSet			*indexes;
 @property(assign,readonly)	BOOL				isPrior;
 


### PR DESCRIPTION
Hi. I've discovered a memory leak caused by `MAKVONotificationCenter` in my project under ARC.

After a short investigation I've found that `MAKVONotification` has a property named `newValue` breaking the Cocoa naming scheme, so ARC assumes it returnes retained value.

I haven't tested my solution under Xcode versions other than 4.3 and with ARC off.
