### PR TITLE
Fix memory leak of block based method

### DIFF
--- a/MAKVONotificationCenter.m
+++ b/MAKVONotificationCenter.m
@@ -191,6 +191,7 @@ static char MAKVONotificationHelperMagicContext = 0;
     _observer = nil;
     _target = nil;
     _keyPaths = nil;
+    _userInfo = nil;
 }
 
 - (BOOL)isValid	// the observation is invalid if and only if it has been deregistered


### PR DESCRIPTION
I ran into an issue that using `addObserver:keyPath:options:block:` causes memory leaks even after calling remove observer method.
