### PR TITLE
Add observation to MAKVONotification

### DIFF
--- a/MAKVONotificationCenter.h
+++ b/MAKVONotificationCenter.h
@@ -58,6 +58,7 @@ enum
 @property(strong,readonly)	id __attribute__((ns_returns_not_retained)) newValue;
 @property(strong,readonly)	NSIndexSet			*indexes;
 @property(assign,readonly)	BOOL				isPrior;
+@property(assign, readonly) id<MAKVOObservation>  observation;
 
 @end
 

--- a/MAKVONotificationCenter.m
+++ b/MAKVONotificationCenter.m
@@ -25,7 +25,7 @@ static NSMutableSet			*MAKVONotificationCenter_swizzledClasses = nil;
     NSDictionary			*change;
 }
 
-- (id)initWithObserver:(id)observer_ object:(id)target_ keyPath:(NSString *)keyPath_ change:(NSDictionary *)change_;
+- (id)initWithObserver:(id)observer_ object:(id)target_ keyPath:(NSString *)keyPath_ change:(NSDictionary *)change_ helper:(id<MAKVOObservation>)helper;
 
 @property(copy,readwrite)	NSString			*keyPath;
 @property(assign,readwrite)	id					observer, target;
@@ -37,7 +37,7 @@ static NSMutableSet			*MAKVONotificationCenter_swizzledClasses = nil;
 
 @synthesize keyPath, observer, target;
 
-- (id)initWithObserver:(id)observer_ object:(id)target_ keyPath:(NSString *)keyPath_ change:(NSDictionary *)change_
+- (id)initWithObserver:(id)observer_ object:(id)target_ keyPath:(NSString *)keyPath_ change:(NSDictionary *)change_ helper:(id<MAKVOObservation>)helper
 {
     if ((self = [super init]))
     {
@@ -45,6 +45,7 @@ static NSMutableSet			*MAKVONotificationCenter_swizzledClasses = nil;
         self.target = target_;
         self.keyPath = keyPath_;
         change = change_;
+      _observation = helper;
     }
     return self;
 }
@@ -142,7 +143,7 @@ static char MAKVONotificationHelperMagicContext = 0;
 
             // Pass object instead of _target as the notification object so that
             //	array observations will work as expected.
-            notification = [[MAKVONotification alloc] initWithObserver:_observer object:object keyPath:keyPath change:change];
+            notification = [[MAKVONotification alloc] initWithObserver:_observer object:object keyPath:keyPath change:change helper:self];
             ((void (^)(MAKVONotification *))_userInfo)(notification);
         }
 #endif


### PR DESCRIPTION
I added observation to MAKVONotification so that I can remove observation from a block like this:

``` swift
    course.addObserver(nil, keyPath:["progress", "contentDownloaded"], options:nil, block: {(note:MAKVONotification!) in
      switch note.keyPath! {
      case "progress":
        println("progress \(course.progress)")
      case "contentDownloaded":
        note.observation.remove()
      default:
        println(note.keyPath)
      }
      })
```
